### PR TITLE
Huge Memory Improvements

### DIFF
--- a/components/Home/helpers/playlists.tsx
+++ b/components/Home/helpers/playlists.tsx
@@ -14,7 +14,7 @@ export default function Playlists({ navigation }: { navigation: NativeStackNavig
 
     return (
         <View>
-            <XStack justifyContent="space-between" alignContent="center" marginHorizontal={"$2"}>
+            <XStack justifyContent="space-evenly" alignContent="center" marginHorizontal={"$2"}>
                 <H2>Your Playlists</H2>
 
                 <YStack justifyContent="center" alignContent="flex-start" marginTop={7}>

--- a/components/Home/helpers/playlists.tsx
+++ b/components/Home/helpers/playlists.tsx
@@ -17,7 +17,7 @@ export default function Playlists({ navigation }: { navigation: NativeStackNavig
             <XStack alignContent="center" marginHorizontal={"$2"}>
                 <H2 flex={4} textAlign="left">Your Playlists</H2>
 
-                <YStack flex={1} justifyContent="center" alignContent="flex-start" marginTop={7}>
+                <YStack flex={1} justifyContent="center" alignContent="center" marginTop={7}>
                     <Icon name="plus-circle-outline" color={getToken("$color.amethyst")} onPress={() => navigation.navigate('AddPlaylist')}/>
                 </YStack>
             </XStack>

--- a/components/Home/helpers/playlists.tsx
+++ b/components/Home/helpers/playlists.tsx
@@ -14,10 +14,10 @@ export default function Playlists({ navigation }: { navigation: NativeStackNavig
 
     return (
         <View>
-            <XStack justifyContent="space-evenly" alignContent="center" marginHorizontal={"$2"}>
-                <H2>Your Playlists</H2>
+            <XStack alignContent="center" marginHorizontal={"$2"}>
+                <H2 flex={4} textAlign="left">Your Playlists</H2>
 
-                <YStack justifyContent="center" alignContent="flex-start" marginTop={7}>
+                <YStack flex={1} justifyContent="center" alignContent="flex-start" marginTop={7}>
                     <Icon name="plus-circle-outline" color={getToken("$color.amethyst")} onPress={() => navigation.navigate('AddPlaylist')}/>
                 </YStack>
             </XStack>

--- a/components/Home/helpers/playlists.tsx
+++ b/components/Home/helpers/playlists.tsx
@@ -15,7 +15,7 @@ export default function Playlists({ navigation }: { navigation: NativeStackNavig
     return (
         <View>
             <XStack alignContent="center" marginHorizontal={"$2"}>
-                <H2 flex={4} textAlign="left">Your Playlists</H2>
+                <H2 flex={5} textAlign="left">Your Playlists</H2>
 
                 <YStack flex={1} justifyContent="center" alignContent="center" marginTop={7}>
                     <Icon name="plus-circle-outline" color={getToken("$color.amethyst")} onPress={() => navigation.navigate('AddPlaylist')}/>

--- a/components/Playlists/component.tsx
+++ b/components/Playlists/component.tsx
@@ -30,6 +30,7 @@ export default function FavoritePlaylists({ navigation }: FavoritePlaylistsProps
                             navigation.navigate("Playlist", { playlist })
                         }}
                         width={width / 2.1}
+                        squared
                     />
                 )
             }}

--- a/constants/query-client.ts
+++ b/constants/query-client.ts
@@ -3,7 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            gcTime: (1000 * 60 * 24 * 24) * 5 // 5 days
+            staleTime: (1000 * 60 * 24 * 1) * 1 // 1 hour
         }
     }
 });

--- a/constants/query-client.ts
+++ b/constants/query-client.ts
@@ -4,7 +4,7 @@ export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             gcTime: (1000 * 60 * 60), // 1 hour
-            staleTime: (1000 * 60 * 30 * 1) * 1 // 1 hour
+            staleTime: (1000 * 60 * 30) // 30 minutes
         }
     }
 });

--- a/constants/query-client.ts
+++ b/constants/query-client.ts
@@ -3,7 +3,8 @@ import { QueryClient } from "@tanstack/react-query";
 export const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            staleTime: (1000 * 60 * 24 * 1) * 1 // 1 hour
+            gcTime: (1000 * 60 * 60), // 1 hour
+            staleTime: (1000 * 60 * 30 * 1) * 1 // 1 hour
         }
     }
 });

--- a/ios/Jellify.xcodeproj/project.pbxproj
+++ b/ios/Jellify.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		00E356F31AD99517003FC87E /* JellifyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* JellifyTests.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		217EBE16A3E8C5FBF476C905 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F757EB73303E0AC21EF34F64 /* PrivacyInfo.xcprivacy */; };
-		6723E797280852DA94E45F9E /* libPods-Jellify.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC45863496A2250140B417A8 /* libPods-Jellify.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		9D518DED9DFA09F244957CA3 /* libPods-Jellify.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9594CD18F25703288E53F586 /* libPods-Jellify.a */; };
 		CF620D0C2CF2BB210045E433 /* Aileron-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = CF620CFC2CF2BB1F0045E433 /* Aileron-Italic.otf */; };
 		CF620D0D2CF2BB210045E433 /* Aileron-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = CF620CFD2CF2BB1F0045E433 /* Aileron-Thin.otf */; };
 		CF620D0E2CF2BB210045E433 /* Aileron-HeavyItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = CF620CFE2CF2BB1F0045E433 /* Aileron-HeavyItalic.otf */; };
@@ -96,9 +96,9 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Jellify/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Jellify/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = Jellify/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		77F973B1ADE26736A0452E9B /* Pods-Jellify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellify.release.xcconfig"; path = "Target Support Files/Pods-Jellify/Pods-Jellify.release.xcconfig"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Jellify/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9200DFFBC18838CD4B4FB0BB /* Pods-Jellify.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellify.debug.xcconfig"; path = "Target Support Files/Pods-Jellify/Pods-Jellify.debug.xcconfig"; sourceTree = "<group>"; };
+		9594CD18F25703288E53F586 /* libPods-Jellify.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Jellify.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A4F7371C0F999CA8BF6AB63D /* Pods-Jellify.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellify.debug.xcconfig"; path = "Target Support Files/Pods-Jellify/Pods-Jellify.debug.xcconfig"; sourceTree = "<group>"; };
 		CF620CFC2CF2BB1F0045E433 /* Aileron-Italic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Aileron-Italic.otf"; path = "../assets/fonts/Aileron-Italic.otf"; sourceTree = "<group>"; };
 		CF620CFD2CF2BB1F0045E433 /* Aileron-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Aileron-Thin.otf"; path = "../assets/fonts/Aileron-Thin.otf"; sourceTree = "<group>"; };
 		CF620CFE2CF2BB1F0045E433 /* Aileron-HeavyItalic.otf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Aileron-HeavyItalic.otf"; path = "../assets/fonts/Aileron-HeavyItalic.otf"; sourceTree = "<group>"; };
@@ -165,7 +165,7 @@
 		CF98CA442D3E99DF003D88B7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CF98CA452D3E99DF003D88B7 /* CarScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarScene.swift; sourceTree = "<group>"; };
 		CF98CA462D3E99DF003D88B7 /* PhoneScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneScene.swift; sourceTree = "<group>"; };
-		EC45863496A2250140B417A8 /* libPods-Jellify.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Jellify.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D86018C31D8B3E14724464F3 /* Pods-Jellify.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jellify.release.xcconfig"; path = "Target Support Files/Pods-Jellify/Pods-Jellify.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F757EB73303E0AC21EF34F64 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = Jellify/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -182,7 +182,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6723E797280852DA94E45F9E /* libPods-Jellify.a in Frameworks */,
+				9D518DED9DFA09F244957CA3 /* libPods-Jellify.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,7 +228,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				EC45863496A2250140B417A8 /* libPods-Jellify.a */,
+				9594CD18F25703288E53F586 /* libPods-Jellify.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -284,8 +284,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9200DFFBC18838CD4B4FB0BB /* Pods-Jellify.debug.xcconfig */,
-				77F973B1ADE26736A0452E9B /* Pods-Jellify.release.xcconfig */,
+				A4F7371C0F999CA8BF6AB63D /* Pods-Jellify.debug.xcconfig */,
+				D86018C31D8B3E14724464F3 /* Pods-Jellify.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -375,13 +375,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Jellify" */;
 			buildPhases = (
-				1CAF0C0C553F5E233AC7F4AA /* [CP] Check Pods Manifest.lock */,
+				081D71B3E1E8263ADAEA56C4 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				04743FC905BCE94857CC6B0B /* [CP] Embed Pods Frameworks */,
-				DE9C3F489EEB5AFE024D7C86 /* [CP] Copy Pods Resources */,
+				7A4483E2AD3253770DCC7298 /* [CP] Embed Pods Frameworks */,
+				61839E5D5E616D171B8339AC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -525,24 +525,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		04743FC905BCE94857CC6B0B /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1CAF0C0C553F5E233AC7F4AA /* [CP] Check Pods Manifest.lock */ = {
+		081D71B3E1E8263ADAEA56C4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -564,7 +547,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DE9C3F489EEB5AFE024D7C86 /* [CP] Copy Pods Resources */ = {
+		61839E5D5E616D171B8339AC /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -579,6 +562,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7A4483E2AD3253770DCC7298 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Jellify/Pods-Jellify-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -669,7 +669,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9200DFFBC18838CD4B4FB0BB /* Pods-Jellify.debug.xcconfig */;
+			baseConfigurationReference = A4F7371C0F999CA8BF6AB63D /* Pods-Jellify.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -708,7 +708,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 77F973B1ADE26736A0452E9B /* Pods-Jellify.release.xcconfig */;
+			baseConfigurationReference = D86018C31D8B3E14724464F3 /* Pods-Jellify.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
Adjust TanStack Query Client garbage collection, stale time

Now memory management is looking a **LOT** better, using 2GB at it's peak, 1GB with music playing and the player open. This fixes a crash that will happen when Hermes throws an OOM

I think this is good for now, this should take us pretty far, but we can always circle back to adjust these configs