### PR TITLE
Made nav bar color match background

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -2,19 +2,23 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import Player from "./Player/stack";
 import { Tabs } from "./tabs";
 import { StackParamList } from "./types";
+import { useTheme } from 'tamagui'
 import DetailsScreen from "./ItemDetail/screen";
 
 export default function Navigation(): React.JSX.Element {
 
   const RootStack = createNativeStackNavigator<StackParamList>()
-  
+
+    const theme = useTheme()
+
     return (
       <RootStack.Navigator>
           <RootStack.Screen 
             name="Tabs" 
             component={Tabs}
             options={{
-              headerShown: false
+              headerShown: false,
+              navigationBarColor: theme.background.val,
             }}
           />
           <RootStack.Screen 


### PR DESCRIPTION
### What is the change

This adds color theming to the nav bar.

### What does this address

On android, the Navigation bar colors cause the Tab navigator to feel cramped:

![Screenshot 2025-04-08 110502](https://github.com/user-attachments/assets/468e4e50-1051-40e7-86cd-a03c8ebf1268)

A simple solution is to change the color to match the background:

![Screenshot 2025-04-08 111728](https://github.com/user-attachments/assets/e31b162b-dae9-4e78-8f94-1beda3373b6d)

### Issue number / link

None

### Tag reviewers
@anultravioletaurora