### PR TITLE
Make password an optional field on sign in

### DIFF
--- a/components/Login/screens/server-authentication.tsx
+++ b/components/Login/screens/server-authentication.tsx
@@ -29,7 +29,7 @@ export default function ServerAuthentication({
 
     const useApiMutation = useMutation({
         mutationFn: async (credentials: JellyfinCredentials) => {
-            return await Client.api!.authenticateUserByName(credentials.username, credentials.password!);
+            return await Client.api!.authenticateUserByName(credentials.username, credentials.password);
         },
         onSuccess: async (authResult) => {
               
@@ -107,7 +107,7 @@ export default function ServerAuthentication({
                 )}
 
                 <Button 
-                    disabled={_.isEmpty(username) || _.isEmpty(password) || useApiMutation.isPending}
+                    disabled={_.isEmpty(username) || useApiMutation.isPending}
                     onPress={() => {
                         
                         if (!_.isUndefined(username)) {


### PR DESCRIPTION
### What is the change
Makes password an optional field when signing in, enabling the "Sign In" button if only the username has been populated

### What does this address
Being unable to sign in with a passwordless user account, which is a valid Jellyfin configuration

### Issue number / link
#224 

### Tag reviewers
@anultravioletaurora