### PR TITLE
Enable ABI-Specific Builds

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -46,7 +46,16 @@ jobs:
           file_pattern: "ios/Jellify.xcodeproj/project.pbxproj"
 
       - name: 🔢 Set artifact version numbers
-        run: mkdir artifacts && mv ./ios/Jellify.ipa ./artifacts/Jellify-${{ env.VERSION_NUMBER }}.ipa && mv ./android/app/build/outputs/apk/release/app-release.apk ./artifacts/Jellify-${{ env.VERSION_NUMBER }}.apk
+        run: |
+          # Move the iOS IPA
+          mv ./ios/Jellify.ipa ./artifacts/Jellify-${{ env.VERSION_NUMBER }}.ipa
+
+          # Move and rename all android release APKs
+          for apk in ./android/app/build/outputs/apk/release/*.apk; do
+            filename=$(basename "$apk")
+            newname="Jellify-${{ env.VERSION_NUMBER }}-${filename}"
+            cp "$apk" "./artifacts/$newname"
+          done
 
       - name: 🎉 Create Github release 
         uses: ncipollo/release-action@v1

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,6 +59,7 @@ react {
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
 def enableProguardInReleaseBuilds = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)
@@ -72,6 +73,14 @@ def enableProguardInReleaseBuilds = false
  * this variant is about 6MiB larger per architecture than default.
  */
 def jscFlavor = 'org.webkit:android-jsc:+'
+
+
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
+
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -104,6 +113,14 @@ android {
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk true  // If true, also generate a universal APK
+            include (*reactNativeArchitectures())
         }
     }
 }

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :android do
 
   desc "Deploy a new version to the Google Play"
   lane :deploy do
-    gradle(task: "clean assembleRelease")
+    gradle(task: "clean bundleRelease")
     upload_to_play_store
   end
 end

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -27,7 +27,7 @@ platform :android do
 
   desc "Deploy a new version to the Google Play"
   lane :deploy do
-    gradle(task: "clean bundleRelease")
+    gradle(task: "clean assembleRelease")
     upload_to_play_store
   end
 end

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pod:install-new-arch": "cd ios && bundle install && RCT_NEW_ARCH_ENABLED=1 bundle exec pod install",
     "fastlane:ios:build": "cd ios && bundle exec fastlane build",
     "fastlane:ios:beta": "cd ios && bundle exec fastlane beta",
-    "fastlane:android:build": "cd android && bundle install && bundle exec fastlane build"
+    "fastlane:android:build": "cd android && bundle install && bundle exec fastlane build",
+    "androidBuild": "cd android && ./gradlew clean && ./gradlew assembleRelease && cd .. && echo 'find apk in android/app/build/outputs/apk/release'"
   },
   "dependencies": {
     "@jellyfin/sdk": "^0.11.0",


### PR DESCRIPTION
### What is the change
1.  Builds separate APKs for each CPU architecture to reduce overall APK size
2. Ensures bundle is uploaded on playstore and not apk.

### What does this address
Smaller APK size (~30mb)
### Issue number / link
N/A

### Tag reviewers
@anultravioletaurora