### PR TITLE
fix issue where albums were cut off when viewing favorite albums

### DIFF
--- a/components/Albums/component.tsx
+++ b/components/Albums/component.tsx
@@ -42,7 +42,7 @@ export default function Albums({ navigation, route }: AlbumsProps) : React.JSX.E
                         onPress={() => {
                             navigation.navigate("Album", { album })
                         }}
-                        width={width / 2.1}
+                        size={"$12"}
                     />   
                 }
             />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jellify",
-  "version": "0.10.84",
+  "version": "0.10.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jellify",
-      "version": "0.10.84",
+      "version": "0.10.87",
       "dependencies": {
         "@jellyfin/sdk": "^0.11.0",
         "@react-native-community/blur": "^4.4.1",


### PR DESCRIPTION
### What is the change
Fixes an issue where favorite albums were cutoff and falling off the screen

| Original | Updated |
|-------------|------------|
|![image](https://github.com/user-attachments/assets/47881c9d-110d-4331-b43b-9d3968f93b0d)| ![image](https://github.com/user-attachments/assets/1d65040d-5c14-4447-9a7f-7b8622854683) |

Also addresses favorite artists not taking up the full viewport

| Original | Updated | 
|------------|-------------|
|![image](https://github.com/user-attachments/assets/ca769d29-628c-484e-81c5-bc5137f532b8) | ![image](https://github.com/user-attachments/assets/c92e0eb0-b742-4c5c-9976-f2a21362bdad) |

### What does this address
Albums falling off the screen when viewing favorite albums. Favorite artists not using the full viewport

### Issue number / link
#242 


### Tag reviewers
@anultravioletaurora @PercyGabriel1129 