### PR TITLE
Add playlist item check cache query key and implement track presence …

### DIFF
--- a/src/enums/query-keys.ts
+++ b/src/enums/query-keys.ts
@@ -74,4 +74,10 @@ export enum QueryKeys {
 	FrequentArtists = 'FrequentArtists',
 	FrequentlyPlayed = 'FrequentlyPlayed',
 	InstantMix = 'InstantMix',
+
+	/**
+	 * Query representing a cache of playlist items used to check if tracks
+	 * are already in playlists to prevent adding duplicates
+	 */
+	PlaylistItemCheckCache = 'PlaylistItemCheckCache',
 }


### PR DESCRIPTION
…check in playlists

### What is the change
this updates the item detail modal's add to playlist section to visualize if the song is already in each of the playlists avoiding some of the confusion around jellyfins api quirk
### What does this address
just cleans up some of the ux, lmk if the design should be changed or anything
![simulator_screenshot_E9214488-D52D-4BF0-93F2-7B3FD34D5C8A](https://github.com/user-attachments/assets/98254d3e-f5cf-4503-829f-72e3ed1d3405)

### Issue number / link

#261
### Tag reviewers
@anultravioletaurora