### PR TITLE
Add "Auto-Download" Toggle to new "Storage" Settings Page

### DIFF
--- a/src/components/Global/helpers/switch-with-label.tsx
+++ b/src/components/Global/helpers/switch-with-label.tsx
@@ -1,6 +1,7 @@
-import { SizeTokens, XStack, Separator, Switch, Theme, styled, getToken, useTheme } from 'tamagui'
+import { SizeTokens, XStack, Separator, Switch, styled, getToken } from 'tamagui'
 import { Label } from './text'
-import { useColorScheme } from 'react-native'
+import { useEffect } from 'react'
+import { trigger } from 'react-native-haptic-feedback'
 
 interface SwitchWithLabelProps {
 	onCheckedChange: (value: boolean) => void
@@ -16,9 +17,12 @@ const JellifySliderThumb = styled(Switch.Thumb, {
 })
 
 export function SwitchWithLabel(props: SwitchWithLabelProps) {
-	const theme = useTheme()
-
 	const id = `switch-${props.size.toString().slice(1)}-${props.checked ?? ''}}`
+
+	useEffect(() => {
+		trigger('impactMedium')
+	}, [props.checked])
+
 	return (
 		<XStack alignItems='center' gap='$3'>
 			<Switch

--- a/src/components/Global/helpers/switch-with-label.tsx
+++ b/src/components/Global/helpers/switch-with-label.tsx
@@ -2,6 +2,7 @@ import { SizeTokens, XStack, Separator, Switch, styled, getToken } from 'tamagui
 import { Label } from './text'
 import { useEffect } from 'react'
 import { trigger } from 'react-native-haptic-feedback'
+import { usePreviousValue } from '../../../hooks/use-previous-value'
 
 interface SwitchWithLabelProps {
 	onCheckedChange: (value: boolean) => void
@@ -19,8 +20,12 @@ const JellifySliderThumb = styled(Switch.Thumb, {
 export function SwitchWithLabel(props: SwitchWithLabelProps) {
 	const id = `switch-${props.size.toString().slice(1)}-${props.checked ?? ''}}`
 
+	const previousChecked = usePreviousValue(props.checked)
+
 	useEffect(() => {
-		trigger('impactMedium')
+		if (previousChecked !== props.checked) {
+			trigger('impactMedium')
+		}
 	}, [props.checked])
 
 	return (

--- a/src/components/Settings/component.tsx
+++ b/src/components/Settings/component.tsx
@@ -7,6 +7,8 @@ import LabsTab from './components/labs-tab'
 import PreferencesTab from './components/preferences-tab'
 import PlaybackTab from './components/playback-tab'
 import InfoTab from './components/info-tab'
+import SettingsTabBar from './components/tab-bar'
+import StorageTab from './components/storage-tab'
 
 const SettingsTabsNavigator = createMaterialTopTabNavigator()
 
@@ -17,8 +19,9 @@ export default function Settings(): React.JSX.Element {
 		<SettingsTabsNavigator.Navigator
 			screenOptions={{
 				tabBarScrollEnabled: true,
+				tabBarGap: getToken('$size.0'),
 				tabBarItemStyle: {
-					width: getToken('$13'),
+					width: getToken('$size.8'),
 				},
 				tabBarShowIcon: true,
 				tabBarActiveTintColor: theme.primary.val,
@@ -27,6 +30,7 @@ export default function Settings(): React.JSX.Element {
 					fontFamily: 'Aileron-Bold',
 				},
 			}}
+			tabBar={(props) => <SettingsTabBar {...props} />}
 		>
 			<SettingsTabsNavigator.Screen
 				name='Settings'
@@ -55,15 +59,12 @@ export default function Settings(): React.JSX.Element {
 			/>
 
 			<SettingsTabsNavigator.Screen
-				name='Account'
-				component={AccountTab}
+				name='Storage'
+				component={StorageTab}
 				options={{
+					title: 'Storage',
 					tabBarIcon: ({ focused, color }) => (
-						<Icon
-							name='account-music'
-							color={focused ? '$primary' : '$borderColor'}
-							small
-						/>
+						<Icon name='harddisk' color={focused ? '$primary' : '$borderColor'} small />
 					),
 				}}
 			/>
@@ -74,6 +75,20 @@ export default function Settings(): React.JSX.Element {
 				options={{
 					tabBarIcon: ({ focused, color }) => (
 						<Icon name='flask' color={focused ? '$primary' : '$borderColor'} small />
+					),
+				}}
+			/>
+
+			<SettingsTabsNavigator.Screen
+				name='Account'
+				component={AccountTab}
+				options={{
+					tabBarIcon: ({ focused, color }) => (
+						<Icon
+							name='account-music'
+							color={focused ? '$primary' : '$borderColor'}
+							small
+						/>
 					),
 				}}
 			/>

--- a/src/components/Settings/components/storage-tab.tsx
+++ b/src/components/Settings/components/storage-tab.tsx
@@ -1,0 +1,30 @@
+import { SafeAreaView } from 'react-native-safe-area-context'
+import SettingsListGroup from './settings-list-group'
+import { SwitchWithLabel } from '../../Global/helpers/switch-with-label'
+import { useSettingsContext } from '../../../providers/Settings'
+
+export default function StorageTab(): React.JSX.Element {
+	const { autoDownload, setAutoDownload } = useSettingsContext()
+	return (
+		<SafeAreaView>
+			<SettingsListGroup
+				settingsList={[
+					{
+						title: 'Automatically Cache Tracks',
+						subTitle: 'Download tracks as they are played',
+						iconName: autoDownload ? 'cloud-download' : 'cloud-off-outline',
+						iconColor: autoDownload ? '$success' : '$borderColor',
+						children: (
+							<SwitchWithLabel
+								size={'$2'}
+								label={autoDownload ? 'Enabled' : 'Disabled'}
+								checked={autoDownload}
+								onCheckedChange={() => setAutoDownload(!autoDownload)}
+							/>
+						),
+					},
+				]}
+			/>
+		</SafeAreaView>
+	)
+}

--- a/src/components/Settings/components/tab-bar.tsx
+++ b/src/components/Settings/components/tab-bar.tsx
@@ -1,0 +1,7 @@
+import { MaterialTopTabBarProps, MaterialTopTabBar } from '@react-navigation/material-top-tabs'
+
+export default function SettingsTabBar(props: MaterialTopTabBarProps): React.JSX.Element {
+	const { state, descriptors, navigation } = props
+
+	return <MaterialTopTabBar {...props} />
+}

--- a/src/hooks/use-previous-value.ts
+++ b/src/hooks/use-previous-value.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react'
+
+export function usePreviousValue(value: boolean) {
+	const previousValue = useRef(value)
+
+	useEffect(() => {
+		previousValue.current = value
+	}, [value])
+
+	return previousValue.current
+}

--- a/src/providers/Player/index.tsx
+++ b/src/providers/Player/index.tsx
@@ -20,6 +20,7 @@ import { PlaystateApi } from '@jellyfin/sdk/lib/generated-client/api/playstate-a
 import { networkStatusTypes } from '../../components/Network/internetConnectionWatcher'
 import { useJellifyContext } from '..'
 import { isUndefined } from 'lodash'
+import { useSettingsContext } from '../Settings'
 
 interface PlayerContext {
 	nowPlaying: JellifyTrack | undefined
@@ -135,6 +136,7 @@ const PlayerContextInitializer = () => {
 
 	const { state: playbackState } = usePlaybackState()
 	const { useDownload, downloadedTracks, networkStatus } = useNetworkContext()
+	const { autoDownload } = useSettingsContext()
 
 	/**
 	 * Use the {@link useTrackPlayerEvents} hook to listen for events from the player.
@@ -160,7 +162,9 @@ const PlayerContextInitializer = () => {
 					// Only download if we are online or *optimistically* if the network status is unknown
 					[networkStatusTypes.ONLINE, undefined, null].includes(
 						networkStatus as networkStatusTypes,
-					)
+					) &&
+					// Only download if auto-download is enabled
+					autoDownload
 				)
 					useDownload.mutate(nowPlaying!.item)
 

--- a/src/providers/Settings/index.tsx
+++ b/src/providers/Settings/index.tsx
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { storage } from '../../constants/storage'
 import { MMKVStorageKeys } from '../../enums/mmkv-storage-keys'
 import { createContext, useContext, useEffect, useState } from 'react'
@@ -9,6 +10,17 @@ interface SettingsContext {
 	setAutoDownload: React.Dispatch<React.SetStateAction<boolean>>
 }
 
+/**
+ * Initializes the settings context
+ *
+ * By default, auto-download is enabled on iOS and Android
+ *
+ * By default, metrics and logs are not sent
+ *
+ * Settings are saved to the device storage
+ *
+ * @returns The settings context
+ */
 const SettingsContextInitializer = () => {
 	const sendMetricsInit = storage.getBoolean(MMKVStorageKeys.SendMetrics)
 
@@ -16,7 +28,9 @@ const SettingsContextInitializer = () => {
 
 	const [sendMetrics, setSendMetrics] = useState(sendMetricsInit ?? false)
 
-	const [autoDownload, setAutoDownload] = useState(autoDownloadInit ?? false)
+	const [autoDownload, setAutoDownload] = useState(
+		autoDownloadInit ?? ['ios', 'android'].includes(Platform.OS),
+	)
 
 	useEffect(() => {
 		storage.set(MMKVStorageKeys.SendMetrics, sendMetrics)


### PR DESCRIPTION
### What is the change
Adds a settings page for managing storage-related settings.

Initial build out includes a toggle for controlling the auto download feature. This is enabled by default on Android and iOS, but can be toggled at any time.

### What does this address
Adding the ability to toggle the auto cache feature

### Issue number / link
#10 
#77 

### Tag reviewers
@anultravioletaurora