### PR TITLE
Fix librarty infinite scrolling

### DIFF
--- a/src/components/Albums/component.tsx
+++ b/src/components/Albums/component.tsx
@@ -82,7 +82,6 @@ export default function Albums({
 							: item.Id!
 				}
 				estimatedItemSize={itemHeight}
-				onEndReachedThreshold={0.25}
 				removeClippedSubviews
 			/>
 		</XStack>

--- a/src/components/Artists/component.tsx
+++ b/src/components/Artists/component.tsx
@@ -134,7 +134,6 @@ export default function Artists({
 				onEndReached={() => {
 					if (hasNextPage) fetchNextPage()
 				}}
-				onEndReachedThreshold={0.8}
 				removeClippedSubviews={false}
 			/>
 

--- a/src/components/Tracks/component.tsx
+++ b/src/components/Tracks/component.tsx
@@ -77,7 +77,6 @@ export default function Tracks({
 			onEndReached={() => {
 				if (hasNextPage) fetchNextPage()
 			}}
-			onEndReachedThreshold={0.0}
 		/>
 	)
 }


### PR DESCRIPTION
### What is the change
Remove `onEndReachedThreshold` for library screens. We will instead rely on the default of `0.5`

### What does this address
Scrolling tabbed sections in the library tab

### Issue number / link


### Tag reviewers
@anultravioletaurora