### PR TITLE
Add support for multiple tracks in playlists

### DIFF
--- a/src/api/mutations/playlists.ts
+++ b/src/api/mutations/playlists.ts
@@ -52,6 +52,52 @@ export async function addToPlaylist(
 }
 
 /**
+ * Adds multiple tracks to a Jellyfin playlist in one request.
+ *
+ * @param api The Jellyfin {@link Api} client
+ * @param user The signed in {@link JellifyUser}
+ * @param tracks The array of {@link BaseItemDto} to add
+ * @param playlist The {@link BaseItemDto} playlist to add the tracks to
+ */
+export async function addManyToPlaylist(
+	api: Api | undefined,
+	user: JellifyUser | undefined,
+	tracks: BaseItemDto[],
+	playlist: BaseItemDto,
+): Promise<void> {
+	console.debug(`Adding ${tracks.length} tracks to playlist`)
+
+	return new Promise<void>((resolve, reject) => {
+		if (isUndefined(api)) return reject(new Error('No API client available'))
+
+		if (isUndefined(user)) return reject(new Error('No user available'))
+
+		const ids = tracks.map((t) => t.Id!).filter(Boolean)
+
+		if (ids.length === 0) return resolve()
+
+		getPlaylistsApi(api)
+			.addItemToPlaylist(
+				{
+					ids,
+					userId: user.id,
+					playlistId: playlist.Id!,
+				},
+				{
+					headers: {},
+				},
+			)
+			.then(() => {
+				resolve()
+			})
+			.catch((error) => {
+				console.error(error)
+				reject(error)
+			})
+	})
+}
+
+/**
  * Removes a track from a Jellyfin playlist.
  *
  * @param api The Jellyfin {@link Api} client

--- a/src/components/AddToPlaylist/types.d.ts
+++ b/src/components/AddToPlaylist/types.d.ts
@@ -1,6 +1,6 @@
 import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client/models'
 
 export interface AddToPlaylistMutation {
-	track: BaseItemDto
+	track?: BaseItemDto
 	playlist: BaseItemDto
 }

--- a/src/components/Context/index.tsx
+++ b/src/components/Context/index.tsx
@@ -86,7 +86,7 @@ export default function ItemContext({
 
 	const renderAddToQueueRow = isTrack || (isAlbum && tracks) || (isPlaylist && tracks)
 
-	const renderAddToPlaylistRow = isTrack
+	const renderAddToPlaylistRow = isTrack || isAlbum
 
 	const renderViewAlbumRow = isAlbum || (isTrack && album)
 
@@ -120,7 +120,13 @@ export default function ItemContext({
 
 				{renderAddToQueueRow && <DownloadMenuRow items={itemTracks} />}
 
-				{renderAddToPlaylistRow && <AddToPlaylistRow track={item} />}
+				{renderAddToPlaylistRow && (
+					<AddToPlaylistRow
+						track={isTrack ? item : undefined}
+						tracks={isAlbum && discs ? discs.flatMap((d) => d.data) : undefined}
+						source={isAlbum ? item : undefined}
+					/>
+				)}
 
 				{(streamingMediaSourceInfo || downloadedMediaSourceInfo) && (
 					<StatsRow
@@ -145,7 +151,15 @@ export default function ItemContext({
 	)
 }
 
-function AddToPlaylistRow({ track }: { track: BaseItemDto }): React.JSX.Element {
+function AddToPlaylistRow({
+	track,
+	tracks,
+	source,
+}: {
+	track?: BaseItemDto
+	tracks?: BaseItemDto[]
+	source?: BaseItemDto
+}): React.JSX.Element {
 	return (
 		<ListItem
 			animation={'quick'}
@@ -155,7 +169,13 @@ function AddToPlaylistRow({ track }: { track: BaseItemDto }): React.JSX.Element 
 			justifyContent='flex-start'
 			onPress={() => {
 				navigationRef.goBack()
-				navigationRef.dispatch(StackActions.push('AddToPlaylist', { track }))
+				navigationRef.dispatch(
+					StackActions.push('AddToPlaylist', {
+						track,
+						tracks,
+						source,
+					}),
+				)
 			}}
 			pressStyle={{ opacity: 0.5 }}
 		>

--- a/src/screens/AddToPlaylist/index.tsx
+++ b/src/screens/AddToPlaylist/index.tsx
@@ -2,5 +2,11 @@ import AddToPlaylist from '../../components/AddToPlaylist/index'
 import { AddToPlaylistProps } from '../types'
 
 export default function AddToPlaylistSheet({ route }: AddToPlaylistProps): React.JSX.Element {
-	return <AddToPlaylist track={route.params.track} />
+	return (
+		<AddToPlaylist
+			track={route.params.track}
+			tracks={route.params.tracks}
+			source={route.params.source}
+		/>
+	)
 }

--- a/src/screens/types.d.ts
+++ b/src/screens/types.d.ts
@@ -62,7 +62,9 @@ export type RootStackParamList = {
 	}
 
 	AddToPlaylist: {
-		track: BaseItemDto
+		track?: BaseItemDto
+		tracks?: BaseItemDto[]
+		source?: BaseItemDto
 	}
 
 	AudioSpecs: {


### PR DESCRIPTION
### What is the change

- Add ability to add entire albums to a playlist:
  - If the Add to Playlist sheet is opened from an album, it now fetches the album’s tracks (discs) when not already provided.
  - Supports adding multiple tracks to a playlist in a single request.
- Prevent duplicate additions:
  - Introduce a lightweight, paginated fetch of playlist item IDs and filter out tracks already present before sending the add request.
- Performance and UX improvements:
  - Paginated retrieval of playlist item IDs with minimal fields to reduce payload.
  - Optimistic-ish UX with per-playlist “adding” state and informative toasts.
  - Targeted cache invalidation for the updated playlist and user playlists.

### What does this address

- Users can quickly add entire albums (all tracks) to playlists without tapping each track.
- Prevents duplicate tracks in playlists by checking existing playlist contents before adding.
- Reduces API calls and payload size through pagination and batched mutations, improving responsiveness.