### PR TITLE
Enhance Android build workflow with keystore password encoding

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -31,6 +31,7 @@ jobs:
         continue-on-error: true
         run: |
           if [ -n "${{ secrets.ANDROID_SIGNING_BASE64 }}" ]; then
+            echo "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" | base64
             echo "${{ secrets.ANDROID_SIGNING_BASE64 }}" | base64 --decode > android/app/jellify.keystore
             echo "Release keystore created"
           else


### PR DESCRIPTION
Added base64 encoding for the keystore password in the build workflow.

### What is the change


### What does this address


### Issue number / link


### Tag reviewers
@anultravioletaurora