### PR TITLE
fix audio normalization delay

### DIFF
--- a/src/providers/Player/index.tsx
+++ b/src/providers/Player/index.tsx
@@ -47,14 +47,14 @@ export const PlayerProvider: () => React.JSX.Element = () => {
 
 			switch (event.type) {
 				case Event.PlaybackActiveTrackChanged:
-					await handleActiveTrackChanged()
-
 					if (event.track) {
 						nowPlaying = event.track as JellifyTrack
 
 						const volume = calculateTrackVolume(nowPlaying)
 						await TrackPlayer.setVolume(volume)
 					}
+
+					await handleActiveTrackChanged()
 
 					if (event.lastTrack)
 						if (isPlaybackFinished(event.lastPosition, event.lastTrack.duration ?? 1))


### PR DESCRIPTION
### What is the change
Makes the audio normalization adjustment occur first thing after the active track has changed

### What does this address
The delay in volume adjustment when playing back tracks in the queue that have audio normalization values

### Issue number / link


### Tag reviewers
@anultravioletaurora