### PR TITLE
Fix "Most Played" Row Not Displaying

### DIFF
--- a/src/api/queries/frequents/index.ts
+++ b/src/api/queries/frequents/index.ts
@@ -33,7 +33,7 @@ export const useFrequentlyPlayedArtists = () => {
 
 	return useInfiniteQuery({
 		queryKey: FrequentlyPlayedArtistsQueryKey(user, library),
-		queryFn: ({ pageParam }) => fetchFrequentlyPlayedArtists(api, library, pageParam),
+		queryFn: ({ pageParam }) => fetchFrequentlyPlayedArtists(api, user, library, pageParam),
 		select: (data) => data.pages.flatMap((page) => page),
 		initialPageParam: 0,
 		getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => {


### PR DESCRIPTION
### What is the change
Adjusts the frequentlyPlayedArtists query to use the cached data from the frequentlyPlayedTracks query, and then fetches the full artist DTOs

### What does this address
Reduces network congestion by eliminating redundant calls

Fix issue where row didn't display

### Issue number / link


### Tag reviewers
@anultravioletaurora