### PR TITLE
Bugfix/playlists not appearing on windows

### DIFF
--- a/src/api/queries/playlist/utils/index.ts
+++ b/src/api/queries/playlist/utils/index.ts
@@ -55,10 +55,9 @@ export async function fetchUserPlaylists(
 			})
 			.then((response) => {
 				if (response.data.Items)
+					// Playlists must be stored in Jellyfin's internal config directory
 					return resolve(
-						response.data.Items.filter((playlist) =>
-							playlist.Path?.includes('jellyfin'),
-						),
+						response.data.Items.filter((playlist) => playlist.Path?.includes('data')),
 					)
 				else return resolve([])
 			})
@@ -92,10 +91,9 @@ export async function fetchPublicPlaylists(
 				console.log(response)
 
 				if (response.data.Items)
+					// Playlists must not be stored in Jellyfin's internal config directory
 					return resolve(
-						response.data.Items.filter(
-							(playlist) => !playlist.Path?.includes('jellyfin'),
-						),
+						response.data.Items.filter((playlist) => !playlist.Path?.includes('data')),
 					)
 				else return resolve([])
 			})


### PR DESCRIPTION
### What is the change
Smol fix to the filter conditions for playlists to check if they're in the internal jellyfin directory structure

### What does this address
Playlists not showing up for Windows hosts

### Issue number / link


### Tag reviewers
@anultravioletaurora