### PR TITLE
feat: add SortName to playlist item fields

### DIFF
--- a/src/api/queries/playlist/utils/index.ts
+++ b/src/api/queries/playlist/utils/index.ts
@@ -133,7 +133,12 @@ export async function fetchPlaylistTracks(
 			Recursive: false,
 			Limit: ApiLimits.Library,
 			StartIndex: pageParam * ApiLimits.Library,
-			Fields: [ItemFields.MediaSources, ItemFields.ParentId, ItemFields.Path],
+			Fields: [
+				ItemFields.MediaSources,
+				ItemFields.ParentId,
+				ItemFields.Path,
+				ItemFields.SortName,
+			],
 		},
 	)
 


### PR DESCRIPTION
Added ItemFields.SortName to the 
fetchPlaylistTracks API request in src/api/queries/playlist/utils/index.ts to ensure complete track metadata is returned.

What does this address
Fixes an issue where playlist tracks would display without names (showing "Untitled Track" or blank). This ensures consistent track metadata is requested from the Jellyfin API.
### Issue number / link
#874 

### Tag reviewers
@anultravioletaurora