### PR TITLE
Made sure explicit icon shows up on album page as well

### DIFF
--- a/src/components/Global/components/Track/content.tsx
+++ b/src/components/Global/components/Track/content.tsx
@@ -142,15 +142,26 @@ export default function TrackRowContent({
 
 				<SlidingTextArea leftGapWidth={artworkAreaWidth} hasArtwork={!!showArtwork}>
 					<YStack alignItems='flex-start' justifyContent='center'>
-						<Text
-							key={`${track.Id}-name`}
-							bold
-							color={textColor}
-							lineBreakStrategyIOS='standard'
-							numberOfLines={1}
-						>
-							{trackName}
-						</Text>
+						<XStack alignItems='center'>
+							<Text
+								key={`${track.Id}-name`}
+								bold
+								color={textColor}
+								lineBreakStrategyIOS='standard'
+								numberOfLines={1}
+							>
+								{trackName}
+							</Text>
+							{!shouldShowArtists && isExplicit(track as JellifyTrack) && (
+								<XStack alignSelf='center' paddingLeft='$2'>
+									<Icon
+										name='alpha-e-box-outline'
+										color={'$borderColor'}
+										xxsmall
+									/>
+								</XStack>
+							)}
+						</XStack>
 
 						{shouldShowArtists && (
 							<XStack alignItems='center'>


### PR DESCRIPTION
### What is the change
Made sure explicit icon shows up on album page as well.

### What does this address
Currently explicit icon doesn't show up on album track list

### Issue number / link
https://github.com/Jellify-Music/App/issues/897#issuecomment-3855521020

### Tag reviewers
@anultravioletaurora