### PR TITLE
Update Album Classification Logic

### DIFF
--- a/src/components/Artist/OverviewTab.tsx
+++ b/src/components/Artist/OverviewTab.tsx
@@ -9,6 +9,12 @@ import ArtistHeader from './header'
 import { Text } from '../Global/helpers/text'
 import SimilarArtists from './similar'
 import { Spinner, useTheme, YStack } from 'tamagui'
+import {
+	filterForAlbums,
+	filterForEPs,
+	filterForSingles,
+	filterForUnknown,
+} from '../../configs/albums.config'
 
 export default function ArtistOverviewTab({
 	navigation,
@@ -23,22 +29,19 @@ export default function ArtistOverviewTab({
 		? [
 				{
 					title: 'Albums',
-					data: albums.filter(({ ChildCount }) => (ChildCount ?? 0) > 6) ?? [],
+					data: albums.filter(filterForAlbums) ?? [],
 				},
 				{
 					title: 'EPs',
-					data:
-						albums.filter(
-							({ ChildCount }) => (ChildCount ?? 0) <= 6 && (ChildCount ?? 0) >= 3,
-						) ?? [],
+					data: albums.filter(filterForEPs) ?? [],
 				},
 				{
 					title: 'Singles',
-					data: albums.filter(({ ChildCount }) => (ChildCount ?? 0) === 1) ?? [],
+					data: albums.filter(filterForSingles) ?? [],
 				},
 				{
-					title: '',
-					data: albums.filter(({ ChildCount }) => typeof ChildCount !== 'number') ?? [],
+					title: 'Other',
+					data: albums.filter(filterForUnknown) ?? [],
 				},
 				{
 					title: 'Featured On',

--- a/src/configs/albums.config.ts
+++ b/src/configs/albums.config.ts
@@ -1,0 +1,22 @@
+import { BaseItemDto } from '@jellyfin/sdk/lib/generated-client'
+import { convertRunTimeTicksToSeconds } from '../utils/mapping/ticks-to-seconds'
+import AlbumRuntimeMinutes from '../enums/album-runtime-minutes'
+
+export const filterForSingles = ({ RunTimeTicks }: BaseItemDto) => {
+	return convertRunTimeTicksToSeconds(RunTimeTicks ?? 0) <= AlbumRuntimeMinutes.Single * 60
+}
+
+export const filterForEPs = ({ RunTimeTicks }: BaseItemDto) => {
+	return (
+		convertRunTimeTicksToSeconds(RunTimeTicks ?? 0) > AlbumRuntimeMinutes.Single * 60 &&
+		convertRunTimeTicksToSeconds(RunTimeTicks ?? 0) <= AlbumRuntimeMinutes.EP * 60
+	)
+}
+
+export const filterForAlbums = ({ RunTimeTicks }: BaseItemDto) => {
+	return convertRunTimeTicksToSeconds(RunTimeTicks ?? 0) > AlbumRuntimeMinutes.EP * 60
+}
+
+export const filterForUnknown = ({ RunTimeTicks }: BaseItemDto) => {
+	return typeof RunTimeTicks !== 'number'
+}

--- a/src/enums/album-runtime-minutes.ts
+++ b/src/enums/album-runtime-minutes.ts
@@ -1,0 +1,7 @@
+enum AlbumRuntimeMinutes {
+	Single = 10,
+	EP = 30,
+	Album = 60,
+}
+
+export default AlbumRuntimeMinutes


### PR DESCRIPTION
### What is the change
Extracts logic for categorizing albums

update album classification based on their runtime, not necessarily their childcount


### What does this address
Album classification on the artist page (Albums, EPs, singles)

### Issue number / link
#1061 

### Tag reviewers
@anultravioletaurora