### PR TITLE
fix: disable Pulsar sound engine so haptics don't produce audible audio

### DIFF
--- a/src/hooks/use-haptic-feedback.ts
+++ b/src/hooks/use-haptic-feedback.ts
@@ -1,5 +1,9 @@
 import { useAppSettingsStore } from '../stores/settings/app'
-import { Presets } from 'react-native-pulsar'
+import { Presets, Settings } from 'react-native-pulsar'
+
+// Disable Pulsar's sound engine so haptic presets only produce vibrations,
+// not audible sound that would route through AirPods / speakers.
+Settings.enableSound(false)
 
 /**
  * Triggers haptic feedback if the user hasn't enabled "Reduce Haptics" setting.


### PR DESCRIPTION
## Summary
- Disables Pulsar's sound engine at module load time so haptic presets only produce vibrations, not audible audio routed through AirPods/speakers

## Test plan
- [x] Toggle the HTTPS switch on the login screen with AirPods connected — should feel haptic only, no sound
- [x] Verify other haptic triggers throughout the app remain vibration-only