### PR TITLE
Security: Potential auth token leakage to third-party domain via shared Axios instance

### DIFF
--- a/src/api/queries/patrons/utils/index.ts
+++ b/src/api/queries/patrons/utils/index.ts
@@ -10,10 +10,10 @@ export default async function fetchPatrons(api: Api | undefined): Promise<Patron
 	return new Promise((resolve, reject) => {
 		if (!api) return reject(new Error('No API instance provided'))
 
-		api.axiosInstance
-			.get(PATRON_API_ENDPOINT)
-			.then((res) => {
-				const patrons = res.data as Patron[]
+		fetch(PATRON_API_ENDPOINT)
+			.then(async (res) => {
+				if (!res.ok) throw new Error(`Request failed with status ${res.status}`)
+				const patrons = (await res.json()) as Patron[]
 				resolve(patrons)
 			})
 			.catch((err) => reject(err))


### PR DESCRIPTION
## Summary

Security: Potential auth token leakage to third-party domain via shared Axios instance

## Problem

**Severity**: `High` | **File**: `src/api/queries/patrons/utils/index.ts:L11`

The patrons request uses `api.axiosInstance.get('https://patrons.jellify.app')`. If the Jellyfin SDK Axios instance is configured with default authentication headers/interceptors, those credentials may be sent to `patrons.jellify.app`, leaking user/session tokens to an external service.

## Solution

Do not use the authenticated Jellyfin Axios instance for third-party domains. Create a separate plain HTTP client (no auth headers/interceptors) for `patrons.jellify.app`, or explicitly strip auth headers before the request.

## Changes

- `src/api/queries/patrons/utils/index.ts` (modified)