### PR TITLE
fix: lower iOS deployment target to 16.4

### DIFF
--- a/ios/Jellify.xcodeproj/project.pbxproj
+++ b/ios/Jellify.xcodeproj/project.pbxproj
@@ -684,7 +684,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -781,7 +781,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -919,7 +919,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
### What is the change

Lowers `IPHONEOS_DEPLOYMENT_TARGET` for the main `Jellify` app target from `18.0` to `16.4` in `ios/Jellify.xcodeproj/project.pbxproj` (Debug, Release, and DevRelease build configurations). The `JellifyTests` target stays at `15.1`.

3-line change, no other modifications.

### What does this address

Closes #1152. The 18.0 floor was inadvertently introduced by #647 (the SwipeableRow / quick-action menu PR bumped `IPHONEOS_DEPLOYMENT_TARGET` from 16.6 → 18.0 alongside an `LastUpgradeVersion` change). It locked out everyone on iOS 17 from installing via TestFlight / App Store, even though nothing in the codebase actually requires iOS 18.

I audited every podspec under `node_modules` for the true binding minimum:

| Source | iOS min |
|---|---|
| `react-native` 0.84.1 (`min_ios_version_supported`) | 15.1 |
| `hermes-engine` | 15.1 |
| `react-native-screens` (hardcoded) | 15.1 |
| All other native deps | ≤ 13.4 |

So 15.1 is technically buildable today. I'm setting the floor to **16.4** rather than 15.1 because Xcode 26 no longer ships iOS 15.x simulator runtimes — 16.4 is the oldest runtime Apple still serves, and shipping a deployment target we can't actually verify against is a worse trade. Anyone on the affected hardware in #1152 (iPhone running iOS 17) is unblocked either way.

Verified: built and ran the app on an `iPhone 14 Pro 16.4` simulator with `RCT_NEW_ARCH_ENABLED=1`. Pod install regenerates 108 pods cleanly; full clean compile succeeds; app launches.

### Issue number / link

Closes #1152

### Tag reviewers
@anultravioletaurora